### PR TITLE
Hide virtual keyboard if searchView text was changed programatically.

### DIFF
--- a/src/com/hughes/android/dictionary/DictionaryActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryActivity.java
@@ -638,6 +638,13 @@ public class DictionaryActivity extends ActionBarActivity {
         }
     }
 
+    private void hideKeyboard() {
+        Log.d(LOG, "Hide soft keyboard.");
+        searchView.clearFocus();
+        InputMethodManager manager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+        manager.hideSoftInputFromWindow(searchView.getWindowToken(), 0);
+    }
+
     void updateLangButton() {
         final LanguageResources languageResources =
                 DictionaryApplication.isoCodeToResources.get(index.shortName);
@@ -1006,7 +1013,7 @@ public class DictionaryActivity extends ActionBarActivity {
         getListView().requestFocus();
 
         // Visual indication that a new keystroke will clear the search text.
-        // Doesn't seem to work unless earchText has focus.
+        // Doesn't seem to work unless searchText has focus.
         // searchView.selectAll();
     }
 
@@ -1108,6 +1115,9 @@ public class DictionaryActivity extends ActionBarActivity {
         // Hide search icon once text is entered
         searchView.setIconifiedByDefault(text.length() > 0);
         searchView.setIconified(false);
+
+        // We don't want to show virtual keyboard when we're changing searchView text programatically:
+        hideKeyboard();
 
         if (triggerSearch) {
             onQueryTextListener.onQueryTextChange(text);


### PR DESCRIPTION
Up/Down buttons handler sets searchView text to match the word in new row, but don't triggers search. And we want searchView to display currently selected row's word.

But after setting text virtual keyboard pops up anyway, so i've fixed setSearchText(...) method to hide it, because we don't want to show keyboard when we are changing searchView text programatically.