### PR TITLE
Prevent crash when DownloadManager is disabled

### DIFF
--- a/src/com/hughes/android/dictionary/DictionaryManagerActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryManagerActivity.java
@@ -616,6 +616,14 @@ public class DictionaryManagerActivity extends ActionBarActivity {
         final DownloadManager.Query query = new DownloadManager.Query();
         query.setFilterByStatus(DownloadManager.STATUS_PAUSED | DownloadManager.STATUS_PENDING | DownloadManager.STATUS_RUNNING);
         final Cursor cursor = downloadManager.query(query);
+
+        if (cursor == null) {
+            new AlertDialog.Builder(DictionaryManagerActivity.this).setTitle(getString(R.string.error))
+                    .setMessage(getString(R.string.downloadFailed, "Couldn't query Download Manager"))
+                    .setNeutralButton("Close", null).show();
+            return;
+        }
+
         while (cursor.moveToNext()) {
             if (downloadUrl.equals(cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_URI))))
                 break;


### PR DESCRIPTION
The other day I [opened an issue](https://github.com/rdoeffinger/Dictionary/issues/25) when quickdic crashed after attempting to download a dictionary. I found out that it was caused by Android's "Download Manager" being disabled via the settings. 

This small patch will display an AlertDialog when the DownloadManager query returns null, preventing a crash if the service is disabled.