### PR TITLE
Make QuickDic handle ACTION_PROCESS_TEXT

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -63,6 +63,11 @@
      			Added two different intents to catch simple and advanced queries from other external applications.
             -->
             <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.SEARCH" />
 
                 <category android:name="android.intent.category.DEFAULT" />

--- a/src/com/hughes/android/dictionary/DictionaryActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryActivity.java
@@ -300,6 +300,15 @@ public class DictionaryActivity extends ActionBarActivity {
             if (query != null)
                 getIntent().putExtra(C.SEARCH_TOKEN, query);
         }
+        /*
+         * This processes text on M+ devices where QuickDic shows up in the context menu.
+         */
+        if (intentAction != null && intentAction.equals(Intent.ACTION_PROCESS_TEXT)) {
+            String query = intent.getStringExtra(Intent.EXTRA_PROCESS_TEXT);
+            if (query != null) {
+                getIntent().putExtra(C.SEARCH_TOKEN, query);
+            }
+        }
         /**
          * @author Dominik Köppl If no dictionary is chosen, use the default
          *         dictionary specified in the preferences If this step does


### PR DESCRIPTION
This shows QuickDic as an option in the text selection context menu of
other apps.

See
https://medium.com/google-developers/custom-text-selection-actions-with-action-process-text-191f792d2999