### PR TITLE
Add "system theme" to theme options

### DIFF
--- a/res/values-de/arrays.xml
+++ b/res/values-de/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>Hell</item>
     <item>Dunkel (Standard)</item>
+    <item>Systemthema</item>
   </string-array>
 
 </resources>

--- a/res/values-es/arrays.xml
+++ b/res/values-es/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>Tema luminoso</item>
     <item>Tema predeterminado</item>
+    <item>Tema del sistema</item>
   </string-array>
 
 </resources>

--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>theme clair</item>
     <item>theme standard</item>
+    <item>theme du system</item>
   </string-array>
   
 </resources>

--- a/res/values-it/arrays.xml
+++ b/res/values-it/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>Tema Light</item>
     <item>Tema di Default</item>
+    <item>Tema di Sistema</item>
   </string-array>
   
 </resources>

--- a/res/values-ja/arrays.xml
+++ b/res/values-ja/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>ライト テーマ</item>
     <item>デフォルト テーマ</item>
+    <item>システムテーマ</item>
   </string-array>
 
 </resources>

--- a/res/values-pt-rBR/arrays.xml
+++ b/res/values-pt-rBR/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>Tema claro</item>
     <item>Tema padrão</item>
+    <item>Tema do sistema</item>
   </string-array>
 
 </resources>

--- a/res/values-ru/arrays.xml
+++ b/res/values-ru/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>Светлая тема</item>
     <item>Тёмная тема (по умолчанию)</item>
+    <item>Системная тема</item>
   </string-array>
 
 </resources>

--- a/res/values-zh-rCN/arrays.xml
+++ b/res/values-zh-rCN/arrays.xml
@@ -12,6 +12,7 @@
   <string-array name="themes">
     <item>亮色主题</item>
     <item>暗色主题（默认）</item>
+    <item>系统主题</item>
   </string-array>
 
 </resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -20,11 +20,13 @@
   <string-array name="themeKeys" translatable="false">
     <item>themeLight</item>
     <item>themeDefault</item>
+    <item>themeSystem</item>
   </string-array>
 
   <string-array name="themes">
     <item>Light theme</item>
     <item>Dark theme (default)</item>
+    <item>System theme</item>
   </string-array>
 
 </resources>

--- a/src/com/hughes/android/dictionary/DictionaryApplication.java
+++ b/src/com/hughes/android/dictionary/DictionaryApplication.java
@@ -18,6 +18,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
@@ -313,6 +314,12 @@ public enum DictionaryApplication {
         final String theme = prefs.getString(appContext.getString(R.string.themeKey), "themeLight");
         if (theme.equals("themeLight")) {
             return Theme.LIGHT;
+        } else if (theme.equals("themeSystem")) {
+            int mode = (appContext.getResources().getConfiguration().uiMode &
+                        Configuration.UI_MODE_NIGHT_MASK);
+            return ((mode == Configuration.UI_MODE_NIGHT_YES) ?
+                    Theme.DEFAULT :
+                    Theme.LIGHT);
         } else {
             return Theme.DEFAULT;
         }

--- a/src/com/hughes/android/dictionary/DictionaryApplication.java
+++ b/src/com/hughes/android/dictionary/DictionaryApplication.java
@@ -317,9 +317,9 @@ public enum DictionaryApplication {
         } else if (theme.equals("themeSystem")) {
             int mode = (appContext.getResources().getConfiguration().uiMode &
                         Configuration.UI_MODE_NIGHT_MASK);
-            return ((mode == Configuration.UI_MODE_NIGHT_YES) ?
-                    Theme.DEFAULT :
-                    Theme.LIGHT);
+            return ((mode == Configuration.UI_MODE_NIGHT_NO) ?
+                    Theme.LIGHT:
+                    Theme.DEFAULT);
         } else {
             return Theme.DEFAULT;
         }


### PR DESCRIPTION
Adds an extra option to the theme settings menu: "system theme". This means light when the system is in day mode, and dark when it is in night mode.