### PR TITLE
Fixed dark theme css

### DIFF
--- a/src/com/hughes/android/dictionary/DictionaryActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryActivity.java
@@ -1579,11 +1579,11 @@ public class DictionaryActivity extends AppCompatActivity {
     private void showHtml(final List<HtmlEntry> htmlEntries, final String htmlTextToHighlight) {
         String html = HtmlEntry.htmlBody(htmlEntries, index.shortName);
         String style = "";
-        if (typeface == Typeface.SERIF) { style = "font-family: serif;"; }
-        else if (typeface == Typeface.SANS_SERIF) { style = "font-family: sans-serif;"; }
-        else if (typeface == Typeface.MONOSPACE) { style = "font-family: monospace;"; }
+        if (typeface == Typeface.SERIF) { style = "* { font-family: serif; } "; }
+        else if (typeface == Typeface.SANS_SERIF) { style = "* { font-family: sans-serif; } "; }
+        else if (typeface == Typeface.MONOSPACE) { style = "* { font-family: monospace; } "; }
         if (application.getSelectedTheme() == DictionaryApplication.Theme.DEFAULT)
-            style += "body { background-color: black; color: white; } a { color: #00aaff; }";
+            style += "body { background-color: #121212; color: #797979; } a { color: #94a8b5; }";
         // Log.d(LOG, "html=" + html);
         startActivityForResult(
             HtmlDisplayActivity.getHtmlIntent(getApplicationContext(), String.format(


### PR DESCRIPTION
The dark theme did not apply correctly everywhere because of broken css, I also added better dark colors (instead of black/white, I choose dark gray for the background and light gray for the text, links will be shown in a bluish gray color)

This fixes #43 

Heres an example of how it will look: 
![](https://i.imgur.com/WB87IVn.png)