### PR TITLE
Issue #141, catch security exception when the Internet permission is denied

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -29,6 +29,7 @@
     <!-- Download. -->
     <string name="downloadFailed">Download failed: \n%s.</string>
     <string name="downloadManagerQueryFailed">Could not query download manager.\nIs it disabled or missing?</string>
+    <string name="downloadManagerQueryPermissionDenied">Internet Permission denied</string>
     <string name="unzippingDictionary">Unzipping dictionary: \n%s</string>
     <string name="unzippingFailed">Unzipping failed: \n%s</string>
     <string name="installationFinished">Installation finished: \n%s.</string>

--- a/src/com/hughes/android/dictionary/DictionaryManagerActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryManagerActivity.java
@@ -84,7 +84,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;


### PR DESCRIPTION
Uses the existing AlertDialog to prompt the user with the download failure. In the case of the SecurityException getting caught, this dialog is displayed irrespective of the 'cancel' parameter. This ensure that the app starts OK and the user is prompted about the lack of Internet Permission for the app.

Missing: translations to supported languages for "Internet Permission denied".