### PR TITLE
Display current word in HTML view title

### DIFF
--- a/src/com/hughes/android/dictionary/DictionaryActivity.java
+++ b/src/com/hughes/android/dictionary/DictionaryActivity.java
@@ -1589,6 +1589,7 @@ public class DictionaryActivity extends AppCompatActivity {
 
     private void showHtml(final List<HtmlEntry> htmlEntries, final String htmlTextToHighlight) {
         String html = HtmlEntry.htmlBody(htmlEntries, index.shortName);
+        String title = HtmlEntry.firstTitle(htmlEntries);
         String style = "";
         if (typeface == Typeface.SERIF) { style = "font-family: serif;"; }
         else if (typeface == Typeface.SANS_SERIF) { style = "font-family: sans-serif;"; }
@@ -1602,7 +1603,7 @@ public class DictionaryActivity extends AppCompatActivity {
         startActivityForResult(
             HtmlDisplayActivity.getHtmlIntent(getApplicationContext(), String.format(
                     "<html><head><meta name=\"viewport\" content=\"width=device-width\"><style type=\"text/css\">%s</style></head><body>%s</body></html>", style, html),
-                                              htmlTextToHighlight, false),
+                                              htmlTextToHighlight, title, false),
             0);
     }
 

--- a/src/com/hughes/android/dictionary/HtmlDisplayActivity.java
+++ b/src/com/hughes/android/dictionary/HtmlDisplayActivity.java
@@ -39,6 +39,7 @@ public final class HtmlDisplayActivity extends AppCompatActivity {
 
     private static final String HTML_RES = "html_res";
     private static final String HTML = "html";
+    private static final String TITLE = "title";
     private static final String TEXT_TO_HIGHLIGHT = "textToHighlight";
     private static final String SHOW_OK_BUTTON = "showOKButton";
 
@@ -55,11 +56,13 @@ public final class HtmlDisplayActivity extends AppCompatActivity {
     }
 
     public static Intent getHtmlIntent(Context c, final String html, final String textToHighlight,
-                                       final boolean showOkButton) {
+                                       final String title, final boolean showOkButton) {
         final Intent intent = new Intent(c, HtmlDisplayActivity.class);
         intent.putExtra(HTML, html);
         intent.putExtra(TEXT_TO_HIGHLIGHT, textToHighlight == null ? "" : textToHighlight);
         intent.putExtra(SHOW_OK_BUTTON, showOkButton);
+        if (title != null)
+            intent.putExtra(TITLE, title);
         return intent;
     }
 
@@ -78,6 +81,10 @@ public final class HtmlDisplayActivity extends AppCompatActivity {
 
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
+
+        final String title = getIntent().getStringExtra(TITLE);
+        if (title != null)
+            setTitle(title);
 
         final int htmlRes = getIntent().getIntExtra(HTML_RES, -1);
         String html;

--- a/src/com/hughes/android/dictionary/engine/HtmlEntry.java
+++ b/src/com/hughes/android/dictionary/engine/HtmlEntry.java
@@ -215,6 +215,10 @@ public class HtmlEntry extends AbstractEntry implements Comparable<HtmlEntry> {
         return result.toString();
     }
 
+    public static String firstTitle(final List<HtmlEntry> htmlEntries) {
+        return htmlEntries.isEmpty() ? null : htmlEntries.get(0).title;
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static String formatQuickdicUrl(final String indexShortName, final String text) {
         assert !indexShortName.contains(":");


### PR DESCRIPTION
I think i will find this useful for long entries. When showing a definition to another person it would be clearer if the opened word is still visible.

I took the first title of the HTML entries. I could not find an example of multiple entries with different titles. I'm not sure if i should have e.g. displayed the full set of titles.